### PR TITLE
fix(shuffle & draw routes)

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ app.get('/', (req, res) => {
 // make a request to the deck of cards api that the student can use to get around cors
 app.get('/deck/new/shuffle', (req, res) => {
   request({
-    url: 'https://deckofcardsapi.com/api/deck/new/shuffle'
+    url: 'https://deckofcardsapi.com/api/deck/new/shuffle/'
   }, (error, response, body) => {
     res.json(JSON.parse(body));
   });

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ app.get('/deck/:deck_id/draw', (req, res) => {
   const { deck_id } = req.params;
 
   request({
-    url: `https://deckofcardsapi.com/api/deck/${deck_id}/draw`
+    url: `https://deckofcardsapi.com/api/deck/${deck_id}/draw/`
   }, (error, response, body) => {
     res.json(JSON.parse(body));
   });


### PR DESCRIPTION
- The /new/shuffle and /deck/:deck_id/draw routes error out with a 404
Not Found error.
- The deck of cards api routes don't seem to work properly without the
trailing slashes. Updating this api to include the trailing slash in
both of the routes mentioned above.